### PR TITLE
chore: Remove deprecated `tflint` configuration

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,7 +1,7 @@
 # Settings are described here: https://github.com/terraform-linters/tflint/blob/main/docs/user-guide/config.md
 config {
   format              = "default"
-  module              = true
+  call_module_type    = "all"
   force               = false
   disabled_by_default = false
 }


### PR DESCRIPTION
The `module` attribute of the `tflint` configuration has been deprecated in favour of the `call_module_type` attribute.