### PR TITLE
fix: Dependabot should only bump Terraform versions in examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,12 @@ version: 2
 
 updates:
   - package-ecosystem: terraform
-    directory: /
+    directories:
+      - examples/**/*
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore(deps)
+      prefix: chore(docs)
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,4 +47,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Lint Terraform Module Documentation
-        uses: craigsloggett/lint-terraform-docs@97735fb800c78410a7978a1e0b6ffe28a8397147 # v1.0.16
+        uses: craigsloggett/lint-terraform-docs@ba4763802eca6237bac648ec92c0444e10df689c # v1.0.17


### PR DESCRIPTION
Reusable modules should not be bumped arbitrarily, that should be done by the module producer when needed (using a feature of a provider that is only available in a specific version). This updates Dependabot configuration to only look in the examples directory where the Terraform code is simulating the consumer of the module (which should keep their providers up to date).