### PR TITLE
chore: Align scaffolding with fleet conventions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in the repo.
-# Unless a later match takes precedence, @usernam will be
+# Unless a later match takes precedence, @MYGITHUBUSERNAME will be
 # requested for review when someone opens a pull request.
-#*       @username
+#*       @MYGITHUBUSERNAME

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,16 @@ jobs:
       - name: Lint YAML Files
         uses: craigsloggett/lint-yaml@d6df6800ae5c8ef98e559cd43257cee8f9e9bf87 # v1.0.18
 
+  shellcheck:
+    name: Shell
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Lint Shell Scripts
+        uses: craigsloggett/lint-shell@92d33c5528427fc13f2883aff90cb7439e3cb56d # v1.0.1
+
   terraform:
     name: Terraform
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
 
       - name: Create a GitHub Release
         id: release
-        uses: craigsloggett/create-github-release@7360c4962908b029931bcd382a7239014745e700 # v1.0.20
+        uses: craigsloggett/create-github-release@afe4170133e10ece0944212d5f105035758ce840 # v1.0.24
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -32,3 +32,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore the dependency lock file; modules leave provider selection to consumers
+*.terraform.lock.hcl

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,7 @@
 extends: relaxed
 
+ignore-from-file: .gitignore
+
 rules:
   comments:
     level: error


### PR DESCRIPTION
- Adds a shellcheck job to the lint workflow
- Switches create-github-release to the `token:` input (coupled pin bump to v1.0.24)
- Fixes the CODEOWNERS placeholder typo (`@usernam`/`@username` → `@MYGITHUBUSERNAME`)
- Ignores `*.terraform.lock.hcl` and strips trailing whitespace in `.gitignore`
- Adds `ignore-from-file: .gitignore` to the yamllint config